### PR TITLE
Updated `denon-client` to fix ZONE2 issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@ var denon = {};
 var roon = new RoonApi({
     extension_id:        'org.pruessmann.roon.denon',
     display_name:        'Denon/Marantz AVR',
-    display_version:     '0.0.10',
+    display_version:     '0.0.11',
     publisher:           'Doc Bobo',
     email:               'boris@pruessmann.org',
     website:             'https://github.com/docbobo/roon-extension-denon',

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "debug": "^3.1.0",
-    "denon-client": "^0.2.0",
+    "denon-client": "^0.2.4",
     "fast-xml-parser": "^3.9.10",
     "node-fetch": "^2.1.2",
     "node-roon-api": "github:roonlabs/node-roon-api#b09c875738360a9413518a8a51ac70294745a926",


### PR DESCRIPTION
I was having this weird behavior with denon-client `0.2.0` where Roon would set ZONE1 to stand by, but would turn ZONE2 on. Updating the library seemed to fix it.